### PR TITLE
Removed parsing of vendor folder, by default. Added supports of './' in `except` & `only`

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ a message source for default language `en`. You can specify the path explicitly:
 php yii translator/extract /path/to/your/project
 ```
 
+**Notice:** By default we exclude folder `vendor` in root folder. For remove this behaviour you can specify empty value of `except`
+```shell
+php yii translator/extract /path/to/your/project --except=''
+```
+
 Full list of options:
 
 ```shell
@@ -157,16 +162,16 @@ php yii translator/extract --category=your_category_name
 
 ### Using `except` option
 
-To exclude `vendor` directory use `--except`:
+To exclude all folders with name `dir1` directory use `--except`:
 
 ```shell
-php yii translator/extract --except=**/vendor/**
+php yii translator/extract --except=**/dir1/**
 ```
 
 To exclude both `vendor` and `tests` directories the following options could be used:
 
 ```shell
-php yii translator/extract --except=**/vendor/** --except=**/tests/**
+php yii translator/extract --except=./vendor/** --except=./tests/**
 ```
 
 ### Using `only` option

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ a message source for default language `en`. You can specify the path explicitly:
 php yii translator/extract /path/to/your/project
 ```
 
-**Notice:** By default we exclude folder `vendor` in root folder. For remove this behaviour you can specify empty value of `except`
+**Notice:** By default extractor has `vendor` directory in the application directory excludede. To include it you can specify empty value for `except`:
 ```shell
 php yii translator/extract /path/to/your/project --except=''
 ```
@@ -162,7 +162,7 @@ php yii translator/extract --category=your_category_name
 
 ### Using `except` option
 
-To exclude all folders with name `dir1` directory use `--except`:
+To exclude all directories named `dir1` use `--except`:
 
 ```shell
 php yii translator/extract --except=**/dir1/**

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ a message source for default language `en`. You can specify the path explicitly:
 php yii translator/extract /path/to/your/project
 ```
 
-**Notice:** By default extractor has `vendor` directory in the application directory excludede. To include it you can specify empty value for `except`:
+**Notice:** By default extractor has `vendor` directory in the application directory excluded. To include it you can specify empty value for `except`:
 ```shell
 php yii translator/extract /path/to/your/project --except=''
 ```

--- a/src/Extractor.php
+++ b/src/Extractor.php
@@ -132,11 +132,16 @@ final class Extractor
         return $returningMessages;
     }
 
-    private function applyRoot(?array $list, $rootFolder): ?array
+    /**
+     * @param string[]|null $list
+     * @param string $rootFolder
+     * @return string[]|null
+     */
+    private function applyRoot(?array $list, string $rootFolder): ?array
     {
         if (is_array($list)) {
             return array_map(
-                static function ($except) use ($rootFolder): string {
+                static function (string $except) use ($rootFolder): string {
                     return preg_replace('#^(\./)#', $rootFolder . '/', $except);
                 },
                 $list

--- a/src/Extractor.php
+++ b/src/Extractor.php
@@ -101,7 +101,7 @@ final class Extractor
          * @var array<array-key, array<string, string>|mixed> $messages
          */
         foreach ($messagesList as $categoryName => $messages) {
-            $output->writeln('<info>Category: "' . $categoryName . '", messages found: ' . count($messages) . '</info>');
+            $output->writeln('<info>Category: "' . $categoryName . '", messages found: ' . count($messages) . '.</info>');
 
             /** @var array<string, array<string, string>> $convertedMessages */
             $convertedMessages = $this->convert($messages);

--- a/src/Extractor.php
+++ b/src/Extractor.php
@@ -143,7 +143,7 @@ final class Extractor
         if (is_array($list)) {
             return array_map(
                 static function (string $except) use ($rootFolder): string {
-                    return preg_replace('#^(\./)#', $rootFolder . DIRECTORY_SEPARATOR, $except);
+                    return preg_replace('#^(\./)#', $rootFolder . '/', $except);
                 },
                 $list
             );

--- a/src/Extractor.php
+++ b/src/Extractor.php
@@ -135,6 +135,7 @@ final class Extractor
     /**
      * @param string[]|null $list
      * @param string $rootFolder
+     *
      * @return string[]|null
      */
     private function applyRoot(?array $list, string $rootFolder): ?array

--- a/src/Extractor.php
+++ b/src/Extractor.php
@@ -16,7 +16,7 @@ use Yiisoft\TranslatorExtractor\Exception\NoCategorySourceConfigException;
 final class Extractor
 {
     /** @var string[]|null */
-    private ?array $except = null;
+    private ?array $except = ['./vendor/**'];
 
     /** @var string[]|null */
     private ?array $only = null;
@@ -81,7 +81,11 @@ final class Extractor
             return;
         }
 
-        $translationExtractor = new TranslationExtractor($filesPath, $this->only, $this->except);
+        $translationExtractor = new TranslationExtractor(
+            $filesPath,
+            $this->applyRoot($this->only, $filesPath),
+            $this->applyRoot($this->except, $filesPath)
+        );
 
         $messagesList = $translationExtractor->extract($defaultCategory);
 
@@ -126,5 +130,19 @@ final class Extractor
         }
 
         return $returningMessages;
+    }
+
+    private function applyRoot(?array $list, $rootFolder): ?array
+    {
+        if (is_array($list)) {
+            return array_map(
+                static function ($except) use ($rootFolder): string {
+                    return preg_replace('#^(\./)#', $rootFolder . '/', $except);
+                },
+                $list
+            );
+        }
+
+        return $list;
     }
 }

--- a/src/Extractor.php
+++ b/src/Extractor.php
@@ -143,7 +143,7 @@ final class Extractor
         if (is_array($list)) {
             return array_map(
                 static function (string $except) use ($rootFolder): string {
-                    return preg_replace('#^(\./)#', $rootFolder . '/', $except);
+                    return preg_replace('#^(\./)#', $rootFolder . DIRECTORY_SEPARATOR, $except);
                 },
                 $list
             );

--- a/tests/CategoryTest.php
+++ b/tests/CategoryTest.php
@@ -12,13 +12,28 @@ use Yiisoft\Translator\MessageWriterInterface;
 
 final class CategoryTest extends TestCase
 {
-    public function testName(): void
+    /**
+     * @dataProvider nameProvider
+     */
+    public function testName(string $categoryName): void
     {
         $this->assertInstanceOf(CategorySource::class, new CategorySource(
-            'testcategoryname',
+            $categoryName,
             $this->createMessageReader(),
             $this->createMessageWriter()
         ));
+    }
+
+    /**
+     * @return \string[][]
+     */
+    public function nameProvider(): array
+    {
+        return [
+            ['testcategoryname'],
+            ['testCategoryName'],
+            ['testCategory1Name']
+        ];
     }
 
     public function testNameException(): void

--- a/tests/CategoryTest.php
+++ b/tests/CategoryTest.php
@@ -32,7 +32,7 @@ final class CategoryTest extends TestCase
         return [
             ['testcategoryname'],
             ['testCategoryName'],
-            ['testCategory1Name']
+            ['testCategory1Name'],
         ];
     }
 

--- a/tests/ExtractCommandTest.php
+++ b/tests/ExtractCommandTest.php
@@ -41,7 +41,7 @@ final class ExtractCommandTest extends TestCase
     {
         $this->command->execute(['path' => __DIR__ . '/not-empty']);
         $output = $this->command->getDisplay();
-        $this->assertStringContainsString('Category: "app", messages found: 2', $output);
+        $this->assertStringContainsString('Category: "app", messages found: 2.', $output);
     }
 
     public function testWithoutDefaultCategory(): void

--- a/tests/ExtractorTest.php
+++ b/tests/ExtractorTest.php
@@ -149,7 +149,8 @@ final class ExtractorTest extends TestCase
         $this->initCategory($categoryName1);
         $this->initCategory($categoryName2);
 
-        $this->extractor->process(__DIR__ . '/multi-categories/app2', $categoryName1, [$language], $this->output);
+        $this->extractor->setOnly(['./app2/**']);
+        $this->extractor->process(__DIR__ . '/multi-categories', $categoryName1, [$language], $this->output);
 
         $this->assertEquals(
             [],

--- a/tests/ExtractorTest.php
+++ b/tests/ExtractorTest.php
@@ -149,7 +149,7 @@ final class ExtractorTest extends TestCase
         $this->initCategory($categoryName1);
         $this->initCategory($categoryName2);
 
-        $this->extractor->setOnly(['./app2' .DIRECTORY_SEPARATOR . '**']);
+        $this->extractor->setOnly(['./app2/**']);
         $this->extractor->process(__DIR__ . '/multi-categories', $categoryName1, [$language], $this->output);
 
         $this->assertEquals(

--- a/tests/ExtractorTest.php
+++ b/tests/ExtractorTest.php
@@ -149,7 +149,7 @@ final class ExtractorTest extends TestCase
         $this->initCategory($categoryName1);
         $this->initCategory($categoryName2);
 
-        $this->extractor->setOnly(['./app2/**']);
+        $this->extractor->setOnly(['./app2' .DIRECTORY_SEPARATOR . '**']);
         $this->extractor->process(__DIR__ . '/multi-categories', $categoryName1, [$language], $this->output);
 
         $this->assertEquals(

--- a/tests/ExtractorTest.php
+++ b/tests/ExtractorTest.php
@@ -62,6 +62,16 @@ final class ExtractorTest extends TestCase
         $this->extractor = new Extractor([]);
     }
 
+    public function testEmptyCategorySourceException(): void
+    {
+        try {
+            $this->extractor = new Extractor([]);
+        } catch (NoCategorySourceConfigException $e) {
+            $this->assertEquals('Please provide a list of CategorySource', $e->getName());
+            $this->assertStringContainsString('CategorySource to be used should be specified in your console config file', $e->getSolution());
+        }
+    }
+
     public function testSimple(): void
     {
         $categoryName = 'app';
@@ -136,6 +146,28 @@ final class ExtractorTest extends TestCase
         );
         $this->assertEquals(
             $this->correctMessagesApp2,
+            $this->categorySource[$categoryName2]->readMessages($categoryName2, $language)
+        );
+    }
+
+    public function testSimpleWithExceptSecondCategory(): void
+    {
+        $categoryName1 = 'app';
+        $categoryName2 = 'app2';
+        $language = 'en';
+
+        $this->initCategory($categoryName1);
+        $this->initCategory($categoryName2);
+
+        $this->extractor->setExcept(['./app2/**']);
+        $this->extractor->process(__DIR__ . '/multi-categories', $categoryName1, [$language], $this->output);
+
+        $this->assertEquals(
+            $this->correctMessagesApp,
+            $this->categorySource[$categoryName1]->readMessages($categoryName1, $language)
+        );
+        $this->assertEquals(
+            [],
             $this->categorySource[$categoryName2]->readMessages($categoryName2, $language)
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #15 
